### PR TITLE
Revise macOS build command in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ This step is only required if you plan to run scripts on the VM.
 If you want to run graphical applications locally (using the VM or C backends), you need to compile a windowing shared library.
 
 * **For macOS (Cocoa backend):**
-    `cd std/win/platform; make cocoa`
+    `cd std/win/platform; make glcocoa coregraphics`
 * **For Linux/X11 (X11/GLX backend):**
     This requires X11 development libraries. On Debian-based systems, you can install them with `sudo apt-get install libx11-dev libgl-dev`. Then, run the following command:
     `cd std/win/platform; make glx`


### PR DESCRIPTION
希望以后makefile 用make可以一键全编译好哈, 为了dither -xvt c cube.gh 花了一晚上都没搞定 (全手动make std_all, make cmdline), 结果今天出来再仔细比较了下, 发现是make cocoa之前编译出错没注意以为完成(因为是按教程来的呀), 现在修改下让大伙别再像我一样出错了是 make glcocoa 😂 , 编译后就可以运行c码了