### PR TITLE
Fix gui issue ( add embed_gui cfg to index.js ) and add build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ The easiest way to try Dither is with the [online editor](https://dither-lang.ne
 
 [![](https://github.com/user-attachments/assets/85d6da4a-fbde-481c-aa7a-a6b03d3cce75)](https://dither-lang.netlify.app/editor.html)
 
+### Build
+- macOS / Linux:  
+>./build.sh  
+>./build.sh dbg=1
+- Windows (MSVC):  
+>build.bat  
+>build.bat dbg=1
+
 You can also [download](https://github.com/LingDong-/dither-lang/releases) the stand-alone single-binary commandline tool for windows, mac or linux.
 
 ```

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+
+echo [build] windows (MSVC)
+
+nmake /f MSVC.mak ^
+    build\config.h ^
+    std_all ^
+    build\vm.exe ^
+    build\vm_dbg.exe ^
+    cmdline ^
+    %*
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+UNAME="$(uname -s)"
+echo "[build] uname = $UNAME"
+case "$UNAME" in
+    Darwin)
+        PLATFORM=macos
+        ;;
+    Linux)
+        PLATFORM=linux
+        ;;
+    *)
+        echo "Unsupported platform: $UNAME"
+        exit 1
+        ;;
+esac
+echo "[build] platform = $PLATFORM"
+
+# ---------- platform-specific std build ----------
+pushd std/win/platform > /dev/null
+if [ "$PLATFORM" = "macos" ]; then
+    make glcocoa coregraphics
+elif [ "$PLATFORM" = "linux" ]; then
+    make glx
+fi
+popd > /dev/null
+
+# ---------- normal build ----------
+make \
+    build/config.h \
+    std_all \
+    build/vm \
+    build/vm_dbg \
+    cmdline \
+    "$@"
+

--- a/editor/cmdline/index.js
+++ b/editor/cmdline/index.js
@@ -7,6 +7,7 @@ const PARSER = require('../../src/parser.js');
 const TO_JS = require('../../src/to_js.js');
 const TO_C = require('../../src/to_c.js');
 const embed_glsl = require('../../src/embed_glsl.js');
+const embed_gui = require('../../src/embed_gui.js');
 
 function tmpth(){
   // let t = _WIN32 ? os.tmpdir() : '/tmp';
@@ -173,7 +174,7 @@ let xprocess = {
 }
 let parser = new PARSER(
   {fs,path,process:xprocess,search_paths},
-  Object.assign({},embed_glsl),
+  Object.assign({},embed_glsl,embed_gui),
 );
 
 if (is_repl){


### PR DESCRIPTION
1. Fix this error
>pkg/prelude/bootstrap.js:1926
>      return wrapper.apply(this.exports, args);  
> ______________^
>TypeError: Cannot read properties of undefined (reading 'exec')
    at doinfer (/snapshot/dither_lang/src/parser.js)
    at doinfer (/snapshot/dither_lang/src/parser.js)
    at PARSER.infertypes (/snapshot/dither_lang/src/parser.js)
    at Object.<anonymous> (/snapshot/dither_lang/editor/cmdline/index.js)
    at Module._compile (pkg/prelude/bootstrap.js:1926:22)
    at Module._extensions..js (node:internal/modules/cjs/loader:1166:10)
    at Module.load (node:internal/modules/cjs/loader:988:32)
    at Module._load (node:internal/modules/cjs/loader:834:12)
    at Function.runMain (pkg/prelude/bootstrap.js:1979:12)
    at node:internal/main/run_main_module:17:47

--------------

2. Add build.sh build.bat
We can run`./build.sh`one-time compilation and installation dither now 😃 